### PR TITLE
Fix the registration passwword validation bug.

### DIFF
--- a/app/src/main/java/com/example/rito/groupapp/Registration_Form.java
+++ b/app/src/main/java/com/example/rito/groupapp/Registration_Form.java
@@ -72,7 +72,7 @@ public class Registration_Form extends AppCompatActivity {
         submit.setOnClickListener(new View.OnClickListener() {
             public void onClick(View view) {
               
-                if (password == password2) {
+                if (password.getText().toString().equals( password2.getText().toString())) {
 
 
                     final Context context = getApplicationContext();
@@ -128,7 +128,7 @@ public class Registration_Form extends AppCompatActivity {
                     });
 
                 }
-                if(password != password2){
+                if(password.getText().toString().equals( password2.getText().toString())==false){
                     Toast.makeText(getBaseContext(), "passwords not the same", Toast.LENGTH_LONG).show();
                 }
             }


### PR DESCRIPTION
Fix the bug that the registration activity keeps tell the user that the "password' and the "confirm password" are not the same therefore fail to register for a new user account.  Uses method "equals" instead of "==" when comparing two password string. 
